### PR TITLE
set functionality for the join mission

### DIFF
--- a/src/components/pages/JoinMission.js
+++ b/src/components/pages/JoinMission.js
@@ -1,5 +1,27 @@
 import React from 'react';
+import { PropTypes } from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { joinMission } from '../../redux/missions/missions';
 
-const JoinMission = () => <div>JoinMission</div>;
+const JoinMission = (props) => {
+  const { isJoined, id } = props;
+  const dispatch = useDispatch();
+
+  const clickButton = () => {
+    dispatch(joinMission(id));
+  };
+  return (
+    <div>
+      <button type="button" onClick={clickButton}>
+        {isJoined ? 'Leave Mission' : 'Join Mission'}
+      </button>
+    </div>
+  );
+};
+
+JoinMission.propTypes = {
+  isJoined: PropTypes.bool.isRequired,
+  id: PropTypes.string.isRequired,
+};
 
 export default JoinMission;

--- a/src/components/pages/Mission.js
+++ b/src/components/pages/Mission.js
@@ -4,7 +4,6 @@ import JoinMission from './JoinMission';
 
 const Mission = (props) => {
   const { mission } = props;
-  console.log('props', mission);
   return (
     <tr>
       <th>

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,6 +1,8 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 const GET_MISSIONS = 'MISSIONS/GET_MISSIONS';
+const JOIN_MISSIONS = 'MISSIONS/GET_MISSIONS';
+const LEAVE_MISSIONS = 'MISSIONS/LEAVE_MISSIONS';
 
 const initialState = [];
 
@@ -18,10 +20,34 @@ export const getMissions = createAsyncThunk(GET_MISSIONS, async () => {
   };
 });
 
+export const joinMission = (id) => ({
+  type: JOIN_MISSIONS,
+  id,
+});
+
+const missionStatus = (state, id, status) => {
+  const newState = state.map((mission) => {
+    if (mission.mission_id !== id) {
+      return mission;
+    }
+    return {
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      mission_description: mission.mission_description,
+      isJoined: status,
+    };
+  });
+  return newState;
+};
+
 const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
     case `${GET_MISSIONS}/fulfilled`:
       return action.payload.missions;
+    case `${JOIN_MISSIONS}`:
+      return missionStatus(state, action.id, true);
+    case `${LEAVE_MISSIONS}`:
+      return missionStatus(state, action.id, false);
     default:
       return state;
   }


### PR DESCRIPTION
In this Pull Request I did the following list below:

- Targeted the specific button in the Join Mission component with the id.
- Dispatch the Join mission action to the reducer and set `isJoined` to true.